### PR TITLE
Update build tooling and document vector renderer plan

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -20,3 +20,6 @@ org.jetbrains.compose.experimental.uikit.enabled=true
 org.jetbrains.compose.experimental.jscanvas.enabled=true
 org.jetbrains.compose.experimental.wasm.enabled=true
 org.jetbrains.compose.experimental.macos.enabled=true
+
+# Enabled parallel sync for Gradle 9.4+
+org.gradle.tooling.parallel=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,18 +1,18 @@
 [versions]
 
-kotlin = "2.3.21"
-compose = "1.10.3"
-agp = "9.2.0"
+kotlin = "2.4.0"
+compose = "1.11.1"
+agp = "9.2.1"
 androidx-appcompat = "1.7.1"
 androidx-activityCompose = "1.13.0"
-compose-uitooling = "1.11.0"
-coroutines-core = "1.10.2"
+compose-uitooling = "1.11.4"
+coroutines-core = "1.11.0"
 kotlinx-serialization = "1.11.0"
-ktorVersion = "3.4.3"
-logback = "1.5.32"
+ktorVersion = "3.5.1"
+logback = "1.5.37"
 androidx-lifecycle = "2.10.0"
 androidx-navigation = "2.9.2"
-kmap = "0.4.1"
+kmap = "0.4.2"
 material3 = "1.9.0"
 
 [libraries]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,50 +1,63 @@
 [versions]
 
-kotlin = "2.4.0"
+# KMaP & DemoApp
+kotlin = "2.4.10"
 compose = "1.11.1"
-agp = "9.2.1"
+agp = "9.3.1"
+coroutines-core = "1.11.0"
+kotlinx-serialization = "1.11.0"
+
+# KMaP
+material3 = "1.9.0"
+
+# DemoApp
 androidx-appcompat = "1.7.1"
 androidx-activityCompose = "1.13.0"
 compose-uitooling = "1.11.4"
-coroutines-core = "1.11.0"
-kotlinx-serialization = "1.11.0"
-ktorVersion = "3.5.1"
-logback = "1.5.37"
-androidx-lifecycle = "2.10.0"
+ktorVersion = "3.5.2"
+logback = "1.6.1"
+androidx-lifecycle = "2.11.0"
 androidx-navigation = "2.9.2"
 kmap = "0.4.2"
-material3 = "1.9.0"
 
 [libraries]
 
+# KMaP & DemoApp
+kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines-core" }
+kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization" }
+kotlinx-serialization-protobuf = { module = "org.jetbrains.kotlinx:kotlinx-serialization-protobuf", version.ref = "kotlinx-serialization" }
+
+# KMaP
+components-resources = { module = "org.jetbrains.compose.components:components-resources", version.ref = "compose" }
+kotlinx-serialization-core = { module = "org.jetbrains.kotlinx:kotlinx-serialization-core", version.ref = "kotlinx-serialization" }
+material3 = { module = "org.jetbrains.compose.material3:material3", version.ref = "material3" }
+runtime = { module = "org.jetbrains.compose.runtime:runtime", version.ref = "compose" }
+
+# DemoApp
 androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "androidx-appcompat" }
 androidx-activityCompose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activityCompose" }
-components-resources = { module = "org.jetbrains.compose.components:components-resources", version.ref = "compose" }
 compose-uitooling = { module = "androidx.compose.ui:ui-tooling", version.ref = "compose-uitooling" }
 androidx-lifecycle-viewmodel = { module = "org.jetbrains.androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "androidx-lifecycle" }
 androidx-lifecycle-runtime-compose = { module = "org.jetbrains.androidx.lifecycle:lifecycle-runtime-compose", version.ref = "androidx-lifecycle" }
 androidx-lifecycle-viewmodel-savedstate = { module = "org.jetbrains.androidx.lifecycle:lifecycle-viewmodel-savedstate", version.ref = "androidx-lifecycle" }
 androidx-navigation-composee = { module = "org.jetbrains.androidx.navigation:navigation-compose", version.ref = "androidx-navigation" }
-kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines-core" }
-kotlinx-coroutines-swing = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-swing", version.ref = "coroutines-core" }
 kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "coroutines-core" }
-kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization" }
-kotlinx-serialization-protobuf = { module = "org.jetbrains.kotlinx:kotlinx-serialization-protobuf", version.ref = "kotlinx-serialization" }
-kotlinx-serialization-core = { module = "org.jetbrains.kotlinx:kotlinx-serialization-core", version.ref = "kotlinx-serialization" }
+kotlinx-coroutines-swing = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-swing", version.ref = "coroutines-core" }
 ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktorVersion" }
 ktor-client-okhttp = { module = "io.ktor:ktor-client-okhttp", version.ref = "ktorVersion" }
 ktor-client-darwin = { module = "io.ktor:ktor-client-darwin", version.ref = "ktorVersion" }
 ktor-client-js = { module = "io.ktor:ktor-client-js", version.ref = "ktorVersion" }
 logback-classic = { module = "ch.qos.logback:logback-classic", version.ref = "logback" }
 kmap = { module = "com.rafambn:KMaP", version.ref = "kmap" }
-material3 = { module = "org.jetbrains.compose.material3:material3", version.ref = "material3" }
-runtime = { module = "org.jetbrains.compose.runtime:runtime", version.ref = "compose" }
 
 [plugins]
 
+# KMaP & DemoApp
 multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 compose = { id = "org.jetbrains.compose", version.ref = "compose" }
-android-application = { id = "com.android.application", version.ref = "agp" }
-android-kmp-library = { id = "com.android.kotlin.multiplatform.library", version.ref = "agp" }
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+android-kmp-library = { id = "com.android.kotlin.multiplatform.library", version.ref = "agp" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
+
+# DemoApp
+android-application = { id = "com.android.application", version.ref = "agp" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Wed Jul 30 12:20:03 BRT 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## Summary

- Upgrade Kotlin, Compose, AGP, Gradle, and supporting dependencies.
- Enable parallel Gradle tooling synchronization.
- Add a detailed plan for asynchronous vector layer rendering.

## Testing

- Not run; changes are limited to build configuration, dependency versions, and documentation.