### PR TITLE
Remove Material3 from KMaP dependencies

### DIFF
--- a/KMaP/build.gradle.kts
+++ b/KMaP/build.gradle.kts
@@ -21,11 +21,11 @@ kotlin {
     jvmToolchain(17)
     android {
         namespace = "com.rafambn.KMaP"
-        compileSdk = 36
+        compileSdk = 37
         minSdk = 24
     }
     jvm()
-    js(IR) {
+    js {
         browser()
         nodejs()
         compilerOptions { useEsClasses = true }
@@ -36,7 +36,6 @@ kotlin {
         d8()
     }
     listOf(
-        iosX64(),
         iosArm64(),
         iosSimulatorArm64(),
         macosArm64()
@@ -50,7 +49,9 @@ kotlin {
     sourceSets {
         commonMain.dependencies {
             implementation(libs.runtime)
-            implementation(libs.material3)
+            implementation(libs.animation)
+            implementation(libs.foundation)
+            implementation(libs.ui)
             implementation(libs.components.resources)
             implementation(libs.kotlinx.coroutines.core)
             implementation(libs.kotlinx.serialization.core)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,9 +7,6 @@ agp = "9.3.1"
 coroutines-core = "1.11.0"
 kotlinx-serialization = "1.11.0"
 
-# KMaP
-material3 = "1.9.0"
-
 # DemoApp
 androidx-appcompat = "1.7.1"
 androidx-activityCompose = "1.13.0"
@@ -28,10 +25,12 @@ kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serializa
 kotlinx-serialization-protobuf = { module = "org.jetbrains.kotlinx:kotlinx-serialization-protobuf", version.ref = "kotlinx-serialization" }
 
 # KMaP
+animation = { module = "org.jetbrains.compose.animation:animation", version.ref = "compose" }
 components-resources = { module = "org.jetbrains.compose.components:components-resources", version.ref = "compose" }
+foundation = { module = "org.jetbrains.compose.foundation:foundation", version.ref = "compose" }
 kotlinx-serialization-core = { module = "org.jetbrains.kotlinx:kotlinx-serialization-core", version.ref = "kotlinx-serialization" }
-material3 = { module = "org.jetbrains.compose.material3:material3", version.ref = "material3" }
 runtime = { module = "org.jetbrains.compose.runtime:runtime", version.ref = "compose" }
+ui = { module = "org.jetbrains.compose.ui:ui", version.ref = "compose" }
 
 # DemoApp
 androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "androidx-appcompat" }


### PR DESCRIPTION
## Summary

- Replace the KMaP Material3 dependency with Compose Animation, Foundation, and UI modules.
- Remove the unused Material3 version and catalog entry.
- Update supported targets and Android compile SDK configuration.

## Testing

- Not run.